### PR TITLE
Fixed problems with common cathode displays and change "number of displays" semantics

### DIFF
--- a/Pi7SegPy.py
+++ b/Pi7SegPy.py
@@ -53,18 +53,20 @@ def setup():
     if common_cathode:
         for key in available_chars:
             available_chars[key] = ~available_chars[key]
+    shift.init(data, clock, latch, chain)
 
 
 def with_dot(value):
-    return value & ~(1 << 7)
-
-shift.init(data, clock, latch, chain)
+    if common_cathode:
+        return value | 1 << 7
+    else:
+        return value & ~(1 << 7)
 
 
 def show(values, dots=[]):
     values.reverse()
     length = len(values)
-    if length > displays*chain:
+    if length > displays:
         raise ValueError("More Characters than available on displays")
     else:
         for i in range(length):
@@ -72,6 +74,9 @@ def show(values, dots=[]):
                 char = available_chars[values[i]]
                 if i+1 in dots:
                     char = with_dot(char)
-                shift.write(char << 8 | 1 << i)
+                if common_cathode:
+                    shift.write(char << 8 | ((~(1 << displays-1-i)) & 0xff))
+                else:
+                    shift.write(char << 8 | 1 << i)
             except KeyError:
                 raise ValueError("The character cannot be printed on a 7 segment display")

--- a/Pi7SegPy.py
+++ b/Pi7SegPy.py
@@ -1,4 +1,5 @@
 import PiShiftPy as shift
+import time
 
 available_chars = {
   0: 0b11000000,
@@ -11,6 +12,16 @@ available_chars = {
   7: 0b11111000,
   8: 0b10000000,
   9: 0b10011000,
+  '0': 0b11000000,
+  '1': 0b11111001,
+  '2': 0b10100100,
+  '3': 0b10110000,
+  '4': 0b10011001,
+  '5': 0b10010010,
+  '6': 0b10000011,
+  '7': 0b11111000,
+  '8': 0b10000000,
+  '9': 0b10011000,
   'A': 0b10001000,
   'b': 0b10000011,
   'C': 0b11000110,
@@ -27,7 +38,12 @@ available_chars = {
   'o': 0b10100011,
   'P': 0b10001100,
   'S': 0b10010010,
-  ' ': 0b11111111
+  'U': 0b11000001,
+  'u': 0b11100011,
+  '-': 0b10111111,
+  "'": 0b11011111,
+  '_': 0b11110111,
+  ' ': 0b11111111,
 }
 
 data = 18
@@ -64,19 +80,19 @@ def with_dot(value):
 
 
 def show(values, dots=[]):
-    values.reverse()
     length = len(values)
     if length > displays:
         raise ValueError("More Characters than available on displays")
     else:
-        for i in range(length):
+        for i in range(length-1, -1, -1):
             try:
                 char = available_chars[values[i]]
                 if i+1 in dots:
                     char = with_dot(char)
                 if common_cathode:
-                    shift.write(char << 8 | ((~(1 << displays-1-i)) & 0xff))
+                    shift.write( (char << 8) | ((~(1 << displays-length+i)) & 0xff))
                 else:
                     shift.write(char << 8 | 1 << i)
+                time.sleep(0.003)
             except KeyError:
                 raise ValueError("The character cannot be printed on a 7 segment display")

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Advanced Usage
 ```python
 import Pi7SegPy as Pi7Seg
 
-Pi7Seg.init(17,27,22,3,8) # Initialize with Data:GPIO17, Clock:GPIO27, Latch:GPIO22, with 3 shift registers (first for active digit selection, others for segment control) and 8 7 segment displays
+Pi7Seg.init(17,27,22,2,8) # Initialize with Data:GPIO17, Clock:GPIO27, Latch:GPIO22, with 2 shift registers (first for active digit selection, second for segment control) and 8 7 segment displays
 
 while True:
     Pi7Seg.show([1,2,3,4,5,6,7,8], [1,2,5]) # Display 12345678 on 8 displays connected to 2 registers with dots enabled on the 1st, 2nd and 5th Digit

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Advanced Usage
 ```python
 import Pi7SegPy as Pi7Seg
 
-Pi7Seg.init(17,27,22,2,4) # Initialize with Data:GPIO17, Clock:GPIO27, Latch:GPIO22, with 2 shift registers and 4 7 segment displays on each register
+Pi7Seg.init(17,27,22,3,8) # Initialize with Data:GPIO17, Clock:GPIO27, Latch:GPIO22, with 3 shift registers (first for active digit selection, others for segment control) and 8 7 segment displays
 
 while True:
     Pi7Seg.show([1,2,3,4,5,6,7,8], [1,2,5]) # Display 12345678 on 8 displays connected to 2 registers with dots enabled on the 1st, 2nd and 5th Digit

--- a/README.rst
+++ b/README.rst
@@ -39,7 +39,7 @@ Advanced Usage
 
     import Pi7SegPy as Pi7Seg
 
-    Pi7Seg.init(17,27,22,3,8) # Initialize with Data:GPIO17, Clock:GPIO27, Latch:GPIO22, with 3 shift registers (first for active digit selection, others for segment control) and 8 7 segment displays 
+    Pi7Seg.init(17,27,22,2,8) # Initialize with Data:GPIO17, Clock:GPIO27, Latch:GPIO22, with 2 shift registers (first for active digit selection, second for segment control) and 8 7 segment displays 
 
     while True:
         Pi7Seg.show([1,2,3,4,5,6,7,8], [1,2,5]) # Display 12345678 on 8 displays connected to 2 registers with dots enabled on the 1st, 2nd and 5th Digit

--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ Defaults
 | 595 Clock: 23
 | 595 Latch: 24
 | No of 595's: 1
-| No of Displays on each 595: 1
+| No of Displays: 1
 | Displays are Common Cathode: False
 
 Code
@@ -39,7 +39,7 @@ Advanced Usage
 
     import Pi7SegPy as Pi7Seg
 
-    Pi7Seg.init(17,27,22,2,4) # Initialize with Data:GPIO17, Clock:GPIO27, Latch:GPIO22, with 2 shift registers and 4 7 segment displays on each register
+    Pi7Seg.init(17,27,22,3,8) # Initialize with Data:GPIO17, Clock:GPIO27, Latch:GPIO22, with 3 shift registers (first for active digit selection, others for segment control) and 8 7 segment displays 
 
     while True:
         Pi7Seg.show([1,2,3,4,5,6,7,8], [1,2,5]) # Display 12345678 on 8 displays connected to 2 registers with dots enabled on the 1st, 2nd and 5th Digit


### PR DESCRIPTION
Fixed problems with common cathode displays and change "number of displays" semantics

Corrected a few problems with common cathode displays:
 * digit selection pin should be set low (added test with binary inversion)
 * digit point segment should be set high (added test with no binary inversion)
 * change from lef to right align

Changed the semantics for number_of_displays parameter, from "display per shift
register" to "total displays" (feels more natural with circuits with variable
number of displays per shift registers pair).